### PR TITLE
fix: renovateのversion-upで範囲指定子を使わなくする

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,11 +2,9 @@
 
 close #{IssueNumber}
 
-### 作成内容
+### 作成内容（Issueに書く必要はないが、一応書いておきたいことあれば）
 
-- [Issue](https://github.com/KonishiKenji/VisionVerse/issues/{IssueNumber})
-
-## 確認事項
+## 何かあれば
 
 〜特になければ項目自体削除
 

--- a/renovate.json
+++ b/renovate.json
@@ -52,13 +52,19 @@
     {
       "automerge": true,
       "matchUpdateTypes": ["patch"]
+    },
+    {
+      "matchPackageNames": [
+        "特定のライブラリ名（範囲指定子にしたいライブラリがあれば）"
+      ],
+      "rangeStrategy": "pin（範囲指定子を付けるか否か）"
     }
   ],
   "pin": {
     "automerge": true
   },
   "prCreation": "immediate",
-  "rangeStrategy": "auto",
+  "rangeStrategy": "pin",
   "repositories": ["PheasantDevil/test-various-tools"],
   "schedule": ["after 9pm and before 11pm every weekday", "every weekend"],
   "statusCheckVerify": true,


### PR DESCRIPTION
## Issue

close #16 

### 作成内容

- [Issue](https://github.com/KonishiKenji/VisionVerse/issues/16)

## 確認事項

〜特になければ項目自体削除

## 備考
